### PR TITLE
2024 Oct 21 - Progress updates for DST

### DIFF
--- a/content/dst/codex/codex-comparison.md
+++ b/content/dst/codex/codex-comparison.md
@@ -52,7 +52,7 @@ Finally, together we'll help in writing the final report at the end of the proce
 
 * fully qualified name: <vac:dst:codex:codex-comparison:matrices-deployments>
 * owner: Wings
-* status: 50%
+* status: 90%
 * start-date: 2024/10/01
 * end-date: 2024/10/18
 
@@ -79,6 +79,10 @@ in the course of a single test.
 * Automated systems for running a matrix of tests and measuring them.
 
 This will build on prior work by DST that benefits from this work as well (ArgoCD work).
+
+#### Status
+* We have working deployments for Waku, which will be adapted to Codex soon
+* We have a theoretically working system for matrices deployments, with a few tweaks and tests needed
 
 ### How Fast Is Codex?
 
@@ -149,7 +153,7 @@ with a Helm chart or plain manifests in it. Use it to support Codex Comparison w
 
 * fully qualified name: <vac:dst:codex:codex-comparison:working-matrices>
 * owner: Wings
-* status: 0%
+* status: 90%
 * start-date: 2024/10/04
 * end-date: 2024/12/31
 
@@ -165,3 +169,7 @@ Test some basic deployments and record findings.
 * A deployment matrix tool or set of instructions/documentation.
 * Deployments tested and working with a 3x3 matrix of different configurations.
 * Used by us or Codex to test Codex and answer questions about it.
+
+#### Status
+* We have a working system for matrices deployments, with a few tweaks and tests needed
+* Needs heterogenous support added

--- a/content/dst/codex/codex-comparison.md
+++ b/content/dst/codex/codex-comparison.md
@@ -132,7 +132,7 @@ We would also like to collect all data from the items in this matrix:
 
 * fully qualified name: `vac:dst:codex:codex-comparison:argocd-or-similar`
 * owner: Wings
-* status: 80%
+* status: 95%
 * start-date: 2024/10/04
 * end-date: 2024/12/31
 
@@ -148,6 +148,10 @@ with a Helm chart or plain manifests in it. Use it to support Codex Comparison w
 * The demonstrated ability to run an nwaku simulation.
 * Deployed Codex comparison test harness.
 
+#### Status
+* We have demonstrated the ability to run nwaku, spawning a deployment from a GitHub issue
+* Deploying a Codex comparison harness is next
+* as is full documentation.
 
 ### Working Matrices
 

--- a/content/dst/ift/vaclab.md
+++ b/content/dst/ift/vaclab.md
@@ -110,8 +110,8 @@ Already done:
 * fully qualified name: `vac:dst:ift:vaclab:better-time-slicing`
 * owner: Wings
 * status: 0%
-* start-date: 2024/10/01
-* end-date: 2024/12/31
+* start-date: 2024/12/01
+* end-date: 2024/12/14
 
 #### Description
 Do a better job of time slicing the lab.

--- a/content/dst/ift/visualiser-tool.md
+++ b/content/dst/ift/visualiser-tool.md
@@ -46,8 +46,8 @@ that don't provide a visual way of analysing large scale behaviours.
 * fully qualified name: `vac:dst:ift:visualiser-tool:debug-visualiser`
 * owner: Alberto
 * status: 0%
-* start-date: 2024/10/01
-* end-date: 2024/12/31
+* start-date: 2024/11/15
+* end-date: 2024/12/10
 
 #### Description
 

--- a/content/dst/index.md
+++ b/content/dst/index.md
@@ -9,7 +9,6 @@ tags:
 ---
 
 ### `ift`
-* [ ] [[dst/ift/deployer-tool|deployer-tool]]
 * [ ] [[dst/ift/visualiser-tool|visualiser-tool]]
 * [ ] [[dst/ift/vaclab|vaclab]]
 

--- a/content/dst/index.md
+++ b/content/dst/index.md
@@ -14,6 +14,7 @@ tags:
 
 ### `waku`
 * [ ] [[dst/waku/waku-scaling|waku-scaling]]
+* [ ] [[dst/waku/waku-evaluation|waku-evaluation]]
 
 ### `codex`
 * [ ] [[dst/codex/codex-base-capacity|codex-base-capacity]]

--- a/content/dst/vac/libp2p-evaluation.md
+++ b/content/dst/vac/libp2p-evaluation.md
@@ -59,9 +59,9 @@ to the Premier Research destination narrative by:
 
 * fully qualified name: <vac:dst:vac:libp2p-evaluation:regression-testing>
 * owner: Alberto
-* status: N/A
-* start-date: N/A
-* end-date: N/A
+* status: Ongoing
+* start-date: 2024-10-01
+* end-date: 2024-12-31
 
 #### Description
 Run different scenarios

--- a/content/dst/waku/waku-evaluation.md
+++ b/content/dst/waku/waku-evaluation.md
@@ -1,0 +1,77 @@
+---
+title: Waku Evaluation
+tags:
+  - "2024q4"
+  - "dst"
+  - "waku"
+draft: false
+description: "Test Waku on a regular basis
+and look for regressions,
+learn scaling properties and run scaling studies,
+understand the limits of Waku and its behaviour.
+Deliver hard numbers and actionable insights.
+Do this monthly, reliably, with strong documentation of findings."
+---
+
+`vac:dst:waku:waku-evaluation`
+
+## Description
+Test Waku on a regular basis
+and look for regressions,
+learn scaling properties and run scaling studies,
+understand the limits of Waku and its behaviour.
+
+We want to learn specific, actionable information
+about Waku's behaviour
+and how it is evolving over time
+with each new release
+and with each thing we are specifically asked to check and test.
+
+We will use a combination of real world testing,
+theoretical analysis and simulation
+to determine and measure the success,
+side effects and other factors of Waku and its evolution.
+
+We will support the Conduit of Expertise narrative directly
+by analysing and evaluating new Waku releases and their features,
+both with regards to features they have today
+and with regards to how that compares to past behaviour.
+
+We will:
+
+* Enable improvements to Waku
+  by allowing for repeatable, measureable
+  and real world insights into Waku,
+  all the way from theory to practice and back.
+* Reduce the risk of a Waku regression
+  making it into a new release of Waku.
+
+Additionally, these efforts will contribute
+to the Premier Research destination narrative by:
+
+* Improving and strengthening our relationship with the Waku team
+  and improving the quality and reputation of IFT's work, inside
+  and outside of Waku.
+
+### Regression testing (recurring)
+
+* fully qualified name: <vac:dst:waku:waku-evaluation:regression-testing>
+* owner: Alberto
+* status: Ongoing
+* start-date: 2024-10-01
+* end-date: 2024-12-31
+
+#### Description
+Run different scenarios
+and collect evidence and data
+of Waku's behaviour.
+
+Test for known regressions
+that have occurred in the past
+and ensure they don't happen again.
+
+#### Deliverables
+* Analysis done
+* Report published with all relevant details
+* Vac Roadmap updated regularly
+  with links to the analysis and results.

--- a/content/dst/waku/waku-evaluation.md
+++ b/content/dst/waku/waku-evaluation.md
@@ -75,3 +75,7 @@ and ensure they don't happen again.
 * Report published with all relevant details
 * Vac Roadmap updated regularly
   with links to the analysis and results.
+
+##### Deliverable reports
+* [ ] [Waku v0.32 regression testing](https://www.notion.so/Waku-regression-testing-v0-32-bd02464a483d402bac92ba4c7086e232)
+* [ ] [Waku v0.33 regression testing](https://www.notion.so/Waku-regression-testing-v0-33-10d8f96fb65c802c846bd3a46ad389eb)

--- a/content/dst/waku/waku-evaluation.md
+++ b/content/dst/waku/waku-evaluation.md
@@ -75,7 +75,3 @@ and ensure they don't happen again.
 * Report published with all relevant details
 * Vac Roadmap updated regularly
   with links to the analysis and results.
-
-##### Deliverable reports
-* [ ] [Waku v0.32 regression testing](https://www.notion.so/Waku-regression-testing-v0-32-bd02464a483d402bac92ba4c7086e232)
-* [ ] [Waku v0.33 regression testing](https://www.notion.so/Waku-regression-testing-v0-33-10d8f96fb65c802c846bd3a46ad389eb)

--- a/content/dst/waku/waku-scaling.md
+++ b/content/dst/waku/waku-scaling.md
@@ -132,8 +132,11 @@ Test the Store protocol at scale.
 #### Deliverables
 - [x] [A report on the results](https://www.notion.so/Test-Store-Protocol-At-Scale-1228f96fb65c80ed9eb8ca7b1d69061d) of the test,
   including analysis, data and metrics.
-- [ ] A list of any issues encountered.
-- [ ] Hard data and metrics from the simulation.
+- [x] [A list of any issues encountered](https://www.notion.so/Test-Store-Protocol-At-Scale-1228f96fb65c80ed9eb8ca7b1d69061d?pvs=4#1228f96fb65c8059a79cebe3b13e8ebb) (no issues reported).
+- [x] [Hard data and metrics from the simulation](https://www.notion.so/Test-Store-Protocol-At-Scale-1228f96fb65c80ed9eb8ca7b1d69061d?pvs=4#1228f96fb65c8059a79cebe3b13e8ebb).
+
+#### Status
+Fully delivered.
 
 ### High Churn Relay+Store Reliability
 

--- a/content/dst/waku/waku-scaling.md
+++ b/content/dst/waku/waku-scaling.md
@@ -122,7 +122,7 @@ that Waku can in fact scale to these sizes and perform reliably.
 
 * fully qualified name: `vac:dst:waku:waku-scaling:test-store-protocol-at-scale`
 * owner: Alberto
-* status: 0%
+* status: 100%
 * start-date: 2024/10/07
 * end-date: 2024/10/18
 

--- a/content/dst/waku/waku-scaling.md
+++ b/content/dst/waku/waku-scaling.md
@@ -130,7 +130,7 @@ that Waku can in fact scale to these sizes and perform reliably.
 Test the Store protocol at scale.
 
 #### Deliverables
-- [ ] A report on the results of the test,
+- [x] [A report on the results](https://www.notion.so/Test-Store-Protocol-At-Scale-1228f96fb65c80ed9eb8ca7b1d69061d) of the test,
   including analysis, data and metrics.
 - [ ] A list of any issues encountered.
 - [ ] Hard data and metrics from the simulation.

--- a/content/dst/waku/waku-scaling.md
+++ b/content/dst/waku/waku-scaling.md
@@ -170,7 +170,7 @@ in heterogenous clusters
 involving different node implementations
 such as nwaku and go-waku.
 
-### Deliverables
+#### Deliverables
 - [ ] A report on the results of each test, including analysis, data and metrics.
 - [ ] A list of any issues encountered.
 - [ ] Hard data and metrics from the simulation.
@@ -188,7 +188,7 @@ Test waku shard behaviour and stability with various of numbers of shards.
 
 Choose a matrix to test for and then test for it.
 
-### Deliverables
+#### Deliverables
 - [ ] Matrix/exact deployment script defined
 - [ ] A report on the results of each test, including analysis, data and metrics.
 - [ ] A list of any issues encountered.
@@ -214,7 +214,7 @@ and the discoveries we make during the course of this work.
 #### Description
 Test the Filter and lightpush protocols at scale.
 
-### Deliverables
+#### Deliverables
 - [ ] A report on the current reliability and performance of the protocols at scale.
 - [ ] Filed any issues encountered.
 - [ ] Hard data and metrics from the simulation.
@@ -230,7 +230,7 @@ Test the Filter and lightpush protocols at scale.
 #### Description
 Measure the bandwidth usage of the Waku discovery protocol using the DiscV5 protocol.
 
-### Deliverables
+#### Deliverables
 - [ ] A report on what you've learnt
 - [ ] Hard data and metrics from the simulation.
 - [ ] A documentation page with analysis and results and notes.


### PR DESCRIPTION
* Remove unused commitment from index (deployer tool)
* Add specific dates to libp2p eval (binds it to the quarter)
* Add Waku evaluation commitment (restoring recurring regression testing)
* Move debug visualiser dates `ift:visualiser-tool:debug-visualiser`
* Moved the dates for ift:vaclab:better-time-slicing
* Add deliverable reports for waku:waku-evaluation:regression-testing](https://github.com/vacp2p/roadmap/pull/31/commits/fe264bc1d1f1eda30728c34ebabbfd3da20534c9)
* Update status of codex:codex-comparison:matrices-deployments+working-matrices
* Update status of codex:codex-comparison:argocd-or-similar
* Update status to 100% `waku:waku-scaling:test-store-protocol-at-scale`
  * [x] @AlbertoSoutullo Please add deliverables to the PR for this task
 
More to come