### PR TITLE
Prepend commitments with `2024q4` label

### DIFF
--- a/content/sc/codex/2024q4-formal-verification.md
+++ b/content/sc/codex/2024q4-formal-verification.md
@@ -8,7 +8,7 @@ draft: false
 description: Implementation of the first agreed upon formal verification rules for the Codex marketplace contracts.
 ---
 
-`vac:sc:codex:formal-verification_2024q4`
+`vac:sc:codex:2024q4-formal-verification`
 
 Implementation of the first agreed upon formal verification rules for the Codex marketplace contracts.
 
@@ -20,7 +20,7 @@ We're collaborating with the Codex team and the Certora team to formally verify 
 
 ### Finish implementing current rules
 
-* fully qualified name: `vac:sc:codex:formal-verification_2024q4:finish-current-rules`
+* fully qualified name: `2024q4-formal-verification:finish-current-rules`
 * owner: r4bbit
 * status: in progress (40%)
 * start-date: 2024/10/14

--- a/content/sc/ift/2024q4-eip-discussions.md
+++ b/content/sc/ift/2024q4-eip-discussions.md
@@ -8,7 +8,7 @@ draft: false
 description: Bi-weekly learn up sessions about Ethereum Improvement Proposals (EIPs) and alike.
 ---
 
-`vac:sc:ift:eip-discussions_2024q4`
+`vac:sc:ift:2024q4-eip-discussions`
 
 Bi-weekly learn up sessions about Ethereum Improvement Proposals (EIPs) and alike.
 
@@ -26,7 +26,7 @@ improving cross-project collaboration.
 
 ### EIP Discussions 2024 Q4
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024q4`
+* fully qualified name: `2024q4-eip-discussions:2024q4`
 * owner: r4bbit
 * status: in progress (20%)
 * start-date: 2024/10/07
@@ -42,7 +42,7 @@ Organize learn up session on a bi-weekly basis and ensure meetings are recorded 
 
 ### EIP Discussions 2024/10/18
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024-10-18`
+* fully qualified name: `2024q4-eip-discussions:2024-10-18`
 * owner: Ricardo
 * status: done
 * start-date: 2024/10/07
@@ -58,7 +58,7 @@ Run a learn up session about either an EIP or similar topic of choice to present
 
 ### EIP Discussions 2024/11/01
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024-11-01`
+* fully qualified name: `2024q4-eip-discussions:2024-11-01`
 * owner: 
 * status: not started
 * start-date: 2024/10/18
@@ -74,7 +74,7 @@ Run a learn up session about either an EIP or similar topic of choice to present
 
 ### EIP Discussions 2024/11/29
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024-11-29`
+* fully qualified name: `2024q4-eip-discussions:2024-11-29`
 * owner: 
 * status: not started
 * start-date: 2024/11/01
@@ -90,7 +90,7 @@ Run a learn up session about either an EIP or similar topic of choice to present
 
 ### EIP Discussions 2024/12/13
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024-12-13`
+* fully qualified name: `2024q4-eip-discussions:2024-12-13`
 * owner: 
 * status: not started
 * start-date: 2024/11/29
@@ -106,7 +106,7 @@ Run a learn up session about either an EIP or similar topic of choice to present
 
 ### EIP Discussions 2024/12/27
 
-* fully qualified name: `vac:sc:ift:eip-discussions_2024q4:2024-12-27`
+* fully qualified name: `2024q4-eip-discussions:2024-12-27`
 * owner: 
 * status: not started
 * start-date: 2024/12/13

--- a/content/sc/index.md
+++ b/content/sc/index.md
@@ -5,18 +5,18 @@ tags:
   - vac
 ---
 
-## `vac:sc:`
+## 2024q4 `vac:sc:`
 ---
 
 ### `ift`:`
-- [ ] [[sc/ift/eip-discussions_2024q4]]
+- [ ] [[sc/ift/2024q4-eip-discussions]]
 
 
 ### `status:`
-- [ ] [[sc/status/staking-protocol-v1]]
-- [ ] [[sc/status/xp-token-v1]]
-- [ ] [[sc/status/xp-nft-v1]]
+- [ ] [[sc/status/2024q4-staking-protocol-v1]]
+- [ ] [[sc/status/2024q4-xp-token-v1]]
+- [ ] [[sc/status/2024q4-xp-nft-v1]]
 
 ### `codex:`
 
-- [ ] [[sc/codex/formal-verification_2024q4]]
+- [ ] [[sc/codex/2024q4-formal-verification]]

--- a/content/sc/status/2024q4-staking-protocol-v1.md
+++ b/content/sc/status/2024q4-staking-protocol-v1.md
@@ -8,7 +8,7 @@ draft: false
 description: Delivery of a first version of the SNT staking protocol for testnet deployment.
 ---
 
-`vac:sc:status:staking-protocol-v1`
+`vac:sc:2024q4-status:staking-protocol-v1`
 
 Delivery of a first version of the SNT staking protocol for testnet deployment.
 
@@ -38,7 +38,7 @@ so we can leverage this work to finalize a first version of the protocol.
 
 ### Merging existing solutions
 
-* fully qualified name: `vac:sc:status:staking-protocol-v1:merging-existing-solutions`
+* fully qualified name: `2024q4-staking-protocol-v1:merging-existing-solutions`
 * owner: ricardo
 * status: done (100%)
 * start-date: 2024/10/07
@@ -66,7 +66,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Upgradeability
 
-* fully qualified name: `vac:sc:status:staking-protocol-v1:upgradeability`
+* fully qualified name: `2024q4-staking-protocol-v1:upgradeability`
 * owner: ricardo
 * status: done(100%)
 * start-date: 2024/10/14
@@ -85,7 +85,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Testing
 
-* fully qualified name: `vac:sc:status:staking-protocol-v1:testing`
+* fully qualified name: `2024q4-staking-protocol-v1:testing`
 * owner: r4bbit 
 * status: in progress (90%)
 * start-date: 2024/10/07
@@ -104,7 +104,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Formal verification
 
-* fully qualified name: `vac:sc:status:staking-protocol-v1:formal-verification`
+* fully qualified name: `2024q4-staking-protocol-v1:formal-verification`
 * owner: r4bbit
 * status: in progress (99%)
 * start-date: 2024/10/07
@@ -123,7 +123,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Documentation
 
-* fully qualified name: `vac:sc:status:staking-protocol-v1:documentation`
+* fully qualified name: `2024q4-staking-protocol-v1:documentation`
 * owner: r4bbit
 * status: in progress (10%)
 * start-date: 2024/12/02

--- a/content/sc/status/2024q4-xp-nft-v1.md
+++ b/content/sc/status/2024q4-xp-nft-v1.md
@@ -8,7 +8,7 @@ draft: false
 description: Development of a first version of the XP NFT contract for Status.
 ---
 
-`vac:sc:status:xp-nft-v1`
+`vac:sc:status:2024q4-xp-nft-v1`
 
 Development of a first version of the XP NFT contract for Status.
 
@@ -36,7 +36,7 @@ Here are the main features and requirements of the first version of this token:
 
 ### Token implementation
 
-* fully qualified name: `vac:sc:status:xp-nft-v1:token-implementation`
+* fully qualified name: `2024q4-xp-nft-v1:token-implementation`
 * owner: Andrea
 * status: done
 * start-date: 2024/10/07
@@ -57,7 +57,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Upgradeability
 
-* fully qualified name: `vac:sc:status:xp-nft-v1:upgradeability`
+* fully qualified name: `2024q4-xp-nft-v1:upgradeability`
 * owner: Andrea
 * status: done (100%)
 * start-date: 2024/10/14

--- a/content/sc/status/2024q4-xp-token-v1.md
+++ b/content/sc/status/2024q4-xp-token-v1.md
@@ -8,7 +8,7 @@ draft: false
 description: Development of a first version of the XP token contract for Status.
 ---
 
-`vac:sc:status:xp-token-v1`
+`vac:sc:status:2024q4-xp-token-v1`
 
 Development of a first version of the XP token contract for Status.
 
@@ -34,7 +34,7 @@ Here are the main features and requirements of the first version of this token:
 
 ### Token implementation
 
-* fully qualified name: `vac:sc:status:xp-token-v1:token-implementation`
+* fully qualified name: `2024q4-xp-token-v1:token-implementation`
 * owner: Andrea
 * status: in progress (90%)
 * start-date: 2024/10/18
@@ -54,7 +54,7 @@ See [this GitHub issue](https://github.com/vacp2p/staking-reward-streamer/issues
 
 ### Formal verification
 
-* fully qualified name: `vac:sc:status:xp-token-v1:formal-verification`
+* fully qualified name: `2024q4-status:xp-token-v1:formal-verification`
 * owner: 
 * status: not started
 * start-date: 2024/10/21


### PR DESCRIPTION
This was discussed offline so we can order commitments and tasks by year and quarter.